### PR TITLE
README: adjust usage of sdf.MinPoly

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ func main() {
 	object, _ = form3.Box(r3.Vec{4, 3, 2}, 1)
 	cone, _ := form3.Cone(6, 1, 0, .1)
 	union := sdf.Union3D(object, cone)
-	union.SetMin(sdf.MinPoly(.4))
+	union.SetMin(sdf.MinPoly(1, .4))
 	object = union
 	err := uirender.EncodeRenderer(os.Stdout, render.NewOctreeRenderer(object, 200))
 	if err != nil {


### PR DESCRIPTION
Somewhere along the way the body of this function changed and requires two arguments as of now.
__________________
Something I noticed while I took my first baby steps with the sdf package and trying the example from this README.
Not sure if the image should be adjusted or what is amiss, because the generated picture looked differently for me with both options tested (0 or 1).